### PR TITLE
Issue 193: Linked SearchResults with Forum categories + styling tweaks

### DIFF
--- a/src/client/components/DisorderResult.js
+++ b/src/client/components/DisorderResult.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import React, { useState } from 'react';
@@ -5,8 +6,6 @@ import { Link, useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import '../style/DisorderResult.css';
 import ReactModal from 'react-modal';
-
-import Button from './Button';
 
 ReactModal.setAppElement('#root');
 
@@ -21,7 +20,6 @@ function DisorderResult({ result }) {
     if (!showModal) {
       setShowModal(true);
     }
-    // document.body.style.overflowY = 'hidden';
   };
 
   const handleCloseModal = () => {
@@ -54,7 +52,10 @@ function DisorderResult({ result }) {
           <div className="close"><i className="fas fa-times" onClick={handleCloseModal} /></div>
 
           <div className="modal-header">
-            <h3 className="disorder-title-modal">{name}</h3>
+            <div className="disorder-header">
+              <h3 className="disorder-title-modal">{name}</h3>
+              <button className="forum-link" type="button" onClick={handleForumLinkClick}>Discussion</button>
+            </div>
             <p className="disorder-category-modal">{category}</p>
             <p className="disorder-sub-category-modal">{sub_category}</p>
           </div>
@@ -79,8 +80,8 @@ function DisorderResult({ result }) {
 }
 
 DisorderResult.propTypes = {
-        result: PropTypes.shape({
-        name: PropTypes.string.isRequired,
+  result: PropTypes.shape({
+    name: PropTypes.string.isRequired,
     category: PropTypes.string,
     sub_category: PropTypes.string,
     diagnostic_criteria: PropTypes.string,

--- a/src/client/components/DisorderResult.js
+++ b/src/client/components/DisorderResult.js
@@ -1,17 +1,21 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import '../style/DisorderResult.css';
 import ReactModal from 'react-modal';
 
 import Button from './Button';
 
-
 ReactModal.setAppElement('#root');
 
 function DisorderResult({ result }) {
   const [showModal, setShowModal] = useState(false);
+  const history = useHistory();
+  const {
+    name, category, description, sub_category, diagnostic_criteria
+  } = result;
 
   const handleOpenModal = () => {
     if (!showModal) {
@@ -25,15 +29,21 @@ function DisorderResult({ result }) {
     document.body.style.overflowY = 'unset';
   };
 
-  const {
-    name, category, description, sub_category, diagnostic_criteria
-  } = result;
+  const handleForumLinkClick = () => {
+    history.push({
+      pathname: '/forum',
+      search: `?category=${name}`,
+    });
+  }
 
   return (
-    <div className="disorder-result" onClick={handleOpenModal}>
-      <h3 className="disorder-title" onClick={handleOpenModal}>{name}</h3>
+    <div className="disorder-result">
+      <div className="disorder-header">
+        <h3 className="disorder-title" onClick={handleOpenModal}>{name}</h3>
+        <button className="forum-link" type="button" onClick={handleForumLinkClick}>Discussion</button>
+      </div>
       <p className="disorder-category" onClick={handleOpenModal}>{category}</p>
-      <p className="disorder-sub-category">{result.sub_category}</p>
+      <p className="disorder-sub-category" onClick={handleOpenModal}>{sub_category}</p>
       <ReactModal
         isOpen={showModal}
         contentLabel="onRequestClose Modal"
@@ -41,7 +51,8 @@ function DisorderResult({ result }) {
         className="disorder-modal"
       >
         <div className="disorder-detailed">
-          <Button className="close" onClick={handleCloseModal}>X</Button>
+          <div className="close"><i className="fas fa-times" onClick={handleCloseModal} /></div>
+
           <div className="modal-header">
             <h3 className="disorder-title-modal">{name}</h3>
             <p className="disorder-category-modal">{category}</p>
@@ -52,15 +63,15 @@ function DisorderResult({ result }) {
             <p className="disorder-diagnostic-criteria">{diagnostic_criteria}</p>
             <h3 className="disorder-section-header">Diagnostic Features</h3>
             <p className="disorder-description">{description}</p>
+            <Link
+              to={{
+                pathname: '/disorderPage',
+                data: result
+              }}
+            >
+              more
+            </Link>
           </div>
-          <Link
-            to={{
-              pathname: '/disorderPage',
-              data: result
-            }}
-          >
-            more
-          </Link>
         </div>
       </ReactModal>
     </div>

--- a/src/client/components/ForumPost.js
+++ b/src/client/components/ForumPost.js
@@ -120,7 +120,7 @@ function ForumPost(props) {
         onRequestClose={handleCloseModal}
         className="post-modal"
       >
-        <button className="close" onClick={handleCloseModal} type="button">X</button>
+        <div className="close"><i className="fas fa-times" onClick={handleCloseModal} /></div>
         <div className="modal-header">
           <div className="line-1-modal">
             <h3 className="post-title-modal">{title}</h3>

--- a/src/client/components/LoginModal.js
+++ b/src/client/components/LoginModal.js
@@ -40,7 +40,7 @@ function LoginModal() {
   return (
     <Modal>
       <div className="modal-close-button">
-        <Button className="close" onClick={handleClose}>X</Button>
+        <div className="close"><i className="fas fa-times" onClick={handleClose} /></div>
       </div>
       <div className="login-modal-header">
         <h3 className="login-title-modal">Login with your Username</h3>

--- a/src/client/components/RegistrationModal.js
+++ b/src/client/components/RegistrationModal.js
@@ -56,7 +56,7 @@ function RegistrationModal() {
   return (
     <Modal isOpen autoFocus>
       <div className="modal-close-button">
-        <Button className="close" onClick={handleClose}>X</Button>
+        <div className="close"><i className="fas fa-times" onClick={handleClose} /></div>
       </div>
       <div className="registration-modal-header">
         <h3 className="registration-title-modal">Registration</h3>

--- a/src/client/components/ResultList.js
+++ b/src/client/components/ResultList.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import DisorderResult from './DisorderResult';
 
-function ResultList({ datasource, filter, filterKey }) {
+function ResultList({ isLoading, datasource, filter, filterKey }) {
   console.log(datasource);
   const dataset = datasource.filter((result) => {
     if (filter === null) { // no filter
@@ -13,12 +13,22 @@ function ResultList({ datasource, filter, filterKey }) {
     return result[filterKey] === filter;
   });
 
-  const uiList = dataset.map(data => (
-    <DisorderResult key={data.name} result={data} />
-  ));
+  const uiList = !isLoading ? dataset.map((data, i) => {
+    let result = (
+      <DisorderResult key={data.name} result={data} />
+    );
+    // Displays dividing line before result if not the last post
+    result = (
+      <div>
+        <hr />
+        {result}
+      </div>
+    );
+    return result;
+  }) : <div className="loading-icon"><i className="fa fa-circle-notch" /></div>;
 
-  if (dataset.length === 0) {
-    return (<h2 className="no-results">No results</h2>);
+  if (dataset.length === 0 && !isLoading) {
+    return (<p className="no-results">No results</p>);
   }
 
   return (

--- a/src/client/pages/Forum.js
+++ b/src/client/pages/Forum.js
@@ -93,29 +93,15 @@ function Forum() {
     window.location.reload(true);
   }
 
-  const posts = data || [];
-  const disorderNames = dataNames ? defaultCategories.concat(dataNames) : defaultCategories;
-  const categoryHeader = category ? (
-    <div className="category-header">
-      <i className="fas fa-times-circle" onClick={handleCategoryClearClick}/>
-      <p className="category-header-text">{category}</p>
-    </div>
-  ) : null;
-
-  return (
-    <div>
-      <div className="forum-content">
-        <div className="forum-header">
-          <div className="header-text">
-            <h1 className="forum-title">Forum</h1>
-            {categoryHeader}
-          </div>
-          <button className="create-post-button" type="button" onClick={handleCreatePostClick}>
-            Create Post
-          </button>
-        </div>
+  function displayForumPosts() {
+    const posts = data || [];
+    if (!isLoading) {
+      if (posts.length === 0) {
+        return <p className="no-results">Nothing here, add something!</p>
+      }
+      return (
         <div className="forum-posts-container">
-          {!isLoading ? posts.map((e, i) => {
+          {posts.map((e, i) => {
             let post = (
               <ForumPost
                 className="post"
@@ -138,8 +124,34 @@ function Forum() {
               );
             }
             return post;
-          }) : <div className="loading-icon"><i className="fa fa-circle-notch" /></div>}
+          })}
         </div>
+      );
+    }
+    return <div className="loading-icon"><i className="fa fa-circle-notch" /></div>;
+  }
+
+  const disorderNames = dataNames ? defaultCategories.concat(dataNames) : defaultCategories;
+  const categoryHeader = category ? (
+    <div className="category-header">
+      <i className="fas fa-times-circle" onClick={handleCategoryClearClick}/>
+      <p className="category-header-text">{category}</p>
+    </div>
+  ) : null;
+
+  return (
+    <div>
+      <div className="forum-content">
+        <div className="forum-header">
+          <div className="header-text">
+            <h1 className="forum-title">Forum</h1>
+            {categoryHeader}
+          </div>
+          <button className="create-post-button" type="button" onClick={handleCreatePostClick}>
+            Create Post
+          </button>
+        </div>
+        {displayForumPosts()}
         <i className="fas fa-stop" />
       </div>
       <ReactModal

--- a/src/client/pages/SearchResults.js
+++ b/src/client/pages/SearchResults.js
@@ -53,8 +53,6 @@ function SearchResults() {
     </p>
   );
 
-  const loading = isLoading && (<p>Loading</p>);
-
   if (error) {
     console.log(error);
   }
@@ -74,8 +72,7 @@ function SearchResults() {
         <ResultsSearchbar terms={terms} onSubmit={handleSearchbarSubmit} />
         {sortedBy}
         <TagList datasource={resultList} filterKey={escapedSortBy} onSelectionChange={tagChange} />
-        {loading}
-        <ResultList datasource={resultList} filterKey={escapedSortBy} filter={selectedTag} />
+        <ResultList datasource={resultList} filterKey={escapedSortBy} filter={selectedTag} isLoading={isLoading}/>
       </div>
     </div>
   );

--- a/src/client/style/DisorderResult.css
+++ b/src/client/style/DisorderResult.css
@@ -19,6 +19,7 @@
 .disorder-header {
   display: flex;
   justify-content: space-between;
+  align-items: flex-start;
 }
 
 .forum-link {
@@ -27,8 +28,9 @@
   border: none;
   color: #fff;
   background: linear-gradient(90deg, rgba(71,221,206,1) 0%, rgba(36,221,135,1) 100%);
-  padding: 0px 1em;
-  margin: .75em 1em;
+  padding: .3em 1.25em;
+  margin: .75em 1%;
+  /* max-height: 2em; */
 }
 
 .forum-link:hover {
@@ -43,6 +45,7 @@
   margin-bottom: 6px;
   margin-left: 1%;
   margin-right: 1%;
+  margin-top: 1%;
 }
 
 .disorder-title:hover {

--- a/src/client/style/DisorderResult.css
+++ b/src/client/style/DisorderResult.css
@@ -1,29 +1,58 @@
 .disorder-result {
   display: inline-block;
-  align-self: center;
   text-align: left;
   border-radius: 8px;
-  padding: 0px 16px;
-  box-shadow: 0px 4px 8px #bbbbbb;
-  width: 90%;
+  width: 100%;
   user-select: none;
-  margin-top: 16px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  transition-duration: 200ms;
+  padding: 0px;
 }
 
-.disorder-result:active{
-  transform: translateY(2px);
-  transition-duration: 5ms;
+.disorder-result:hover {
+  transition-duration: 200ms;
+  box-shadow: 0px 0px 8px #bbbbbb;
+  border-radius: 8px;
+}
+
+.disorder-header {
+  display: flex;
+  justify-content: space-between;
+}
+
+.forum-link {
+  font-family: 'Open Sans', Arial, sans-serif;
+  border-radius: 90px;
+  border: none;
+  color: #fff;
+  background: linear-gradient(90deg, rgba(71,221,206,1) 0%, rgba(36,221,135,1) 100%);
+  padding: 0px 1em;
+  margin: .75em 1em;
+}
+
+.forum-link:hover {
+  background: linear-gradient(90deg, rgba(158,219,213,1) 0%, rgba(138,217,180,1) 100%);
+  cursor: pointer;
 }
 
 .disorder-title {
   font-family: 'Merriweather', Times, serif;
-  font-size: 18px;
+  font-size: 1.25em;
+  font-weight: bold;
   margin-bottom: 6px;
+  margin-left: 1%;
+  margin-right: 1%;
+}
+
+.disorder-title:hover {
+  cursor: pointer;
 }
 
 .disorder-title-modal{
   font-family: 'Merriweather', Times, serif;
-  font-size: 24px;
+  font-size: 2em;
+  font-weight: bold;
   margin-bottom: 6px;
   color: #fff;
 }
@@ -34,6 +63,13 @@
   font-size: 16px;
   margin-top: 0px;
   margin-bottom: 0px;
+  width: 90%;
+  margin-left: 1%;
+  margin-right: 1%;
+}
+
+.disorder-category:hover {
+  cursor: pointer;
 }
 
 .disorder-category-modal {
@@ -49,6 +85,13 @@
   color: #999;
   font-size: 16px;
   margin-top: 0px;
+  width: 90%;
+  margin-left: 1%;
+  margin-right: 1%;
+}
+
+.disorder-sub-category:hover {
+  cursor: pointer;
 }
 
 .disorder-sub-category-modal{
@@ -114,6 +157,7 @@
 
 .close:hover{
   color: rgb(209, 209, 209);
+  cursor: pointer
 }
 
 .ReactModal__Overlay {
@@ -127,8 +171,4 @@
 
 .ReactModal__Overlay--before-close{
   opacity: 0;
-}
-
-.DisorderResult{
-  margin-top: 50px;
 }

--- a/src/client/style/Forum.css
+++ b/src/client/style/Forum.css
@@ -174,5 +174,5 @@ hr {
   animation: spin;
   animation-iteration-count: infinite;
   animation-duration: 1s;
-  animation-timing-function: linear;
+  animation-timing-function: ease-in-out;
 }

--- a/src/client/style/SearchResults.css
+++ b/src/client/style/SearchResults.css
@@ -1,5 +1,4 @@
 .search-results-title {
-  /* text-align: left; */
   float: left;
   font-family: 'Open Sans', Arial, sans-serif;
 }
@@ -16,9 +15,9 @@
 
 .search-results-container{
   border-radius: 8px;
-  padding: .5rem 1rem;
+  padding: 0px;
   box-shadow: 0px 4px 8px #bbbbbb; /* absolutle units don't matter here */
-  width: 85%;
+  width: 90vw;
   align-self: center;
   justify-content: center;
   align-items: center;
@@ -29,6 +28,14 @@
 h1 {
   text-align: center;
   font-size: 24px;
+}
+
+hr {
+  background-color: #e0e0e0;
+  height: 1px;
+  border-width: 0px;
+  padding: 0px;
+  margin: 0px;
 }
 
 .number-of-entries{
@@ -44,22 +51,25 @@ h1 {
   font-family: 'Open Sans', Arial, sans-serif;
   text-align: center;
   font-size: 24px;
-  padding-top: 8px;
+  padding-top: 1%;
+  padding-bottom: 2%; 
+  color: #666;
 }
 
 .resultlist{
   display: flex;
   margin-top: 0px;
+  padding: 0px;
   justify-content: center;
   flex-direction: column;
-  padding-bottom: 24px;
+  padding-bottom: 0px;
 }
 
 .sortedBy {
   font-family: 'Open Sans', Arial, sans-serif;
   color: gray;
-  text-align: left;
-  /* margin-left: 40px; */
-  margin-left: 4em;
-  margin-bottom: 0;
+  text-align: right;
+  margin-right: 6em;
+  margin-bottom: 1em;
+
 }


### PR DESCRIPTION
Add link from a DisorderResult directly to the relevant Forum category. 

Unfortunately, to get the new button to work, you can no longer click anywhere on the result listing to enter the modal, you need to click the actual text. If this bothers anyone too much I can look into a fix, but I am lazy

Also I couldn't figure out a good way to link the other way, from forum category to disorder result. I don't think this is a huge issue either (because I'm lazy) but also because I feel that use case is fairly limited. I'll open a new issue, but for our deadline I'd consider this feature complete.

Other stuff:
-Cleaned up SearchResults styling to be consistent with Forum styling
-Replaced 'X' close button on modals with an icon

closes #193